### PR TITLE
Fix #76 - green link color

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -3,6 +3,7 @@
 $pm-primary: $pv-green;
 $pm-primary-dark: $pv-green-dark;
 $pm-primary-light: $pv-green-light;
+$color-links: $pm-primary;
 
 @import '~react-components/styles/index';
 @import '~design-system/_sass/pv-styles/pv-indicator';


### PR DESCRIPTION
Link are green now :)

- just added `$color-links: $pm-primary;` in `app.scss`

![image](https://user-images.githubusercontent.com/2578321/63791375-a7daed80-c8fb-11e9-880c-3796b7019644.png)
